### PR TITLE
feat(schema): add input can be optional on model configuration

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: hasura
 on:
   push:
     branches:
-      - "*"
+      - "**"
     tags:
       - v*
   pull_request:
@@ -33,6 +33,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Compute sanitized branch tag
+        run: |
+          SAFE_BRANCH="${GITHUB_REF_NAME}"
+          # Docker tag spec forbids '/'; replace with '-' so slash-containing branches build
+          echo "SAFE_BRANCH=${SAFE_BRANCH//\//-}" >> $GITHUB_ENV
+
       - name: Create environment variable with the commit id
         run: |
           echo "DOCKER_TAG=${GITHUB_SHA}" >> $GITHUB_ENV
@@ -60,7 +66,7 @@ jobs:
         with:
           push: true
           context: .
-          tags: ${{ env.DOCKER_IMAGE_REPOSITORY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ steps.branch-name.outputs.current_branch }}, ${{ env.DOCKER_IMAGE_REPOSITORY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_TAG }}
+          tags: ${{ env.DOCKER_IMAGE_REPOSITORY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.SAFE_BRANCH }}, ${{ env.DOCKER_IMAGE_REPOSITORY }}/${{ env.DOCKER_IMAGE_NAME }}:${{ env.DOCKER_TAG }}
           file: ${{ env.DOCKER_FILE}}
           platforms: linux/amd64,linux/arm64
 

--- a/metadata/tables.yaml
+++ b/metadata/tables.yaml
@@ -3102,12 +3102,14 @@
       columns: &id007
       - configuration_id
       - input_id
+      - is_optional
   select_permissions:
   - role: anonymous
     permission:
       columns:
       - configuration_id
       - input_id
+      - is_optional
       filter: {}
   - role: user
     permission:

--- a/migrations/1771200016000_modelcatalog_configuration_input_is_optional/down.sql
+++ b/migrations/1771200016000_modelcatalog_configuration_input_is_optional/down.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE modelcatalog_configuration_input
+    DROP COLUMN is_optional;
+COMMIT;

--- a/migrations/1771200016000_modelcatalog_configuration_input_is_optional/up.sql
+++ b/migrations/1771200016000_modelcatalog_configuration_input_is_optional/up.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE modelcatalog_configuration_input
+    ADD COLUMN is_optional BOOLEAN NOT NULL DEFAULT FALSE;
+COMMIT;


### PR DESCRIPTION
## Summary

- Widen `docker-publish.yml` trigger from `branches: '*'` to `branches: '**'` so slashed branch names (e.g. `gsd/phase-12-is-optional`) actually publish images.
- Add SAFE_BRANCH step that replaces `/` with `-` in `GITHUB_REF_NAME`, then tag the image with `SAFE_BRANCH` instead of the raw `tj-actions/branch-names@v6` output (which is an invalid Docker tag when it contains `/`).

Mirrors fixes already applied in [ui e0547dd](https://github.com/mintproject/mint-ui-lit/commit/e0547dd) and [model-catalog-api 7109442](https://github.com/mintproject/model-catalog-api/commit/7109442).

## Verification

- CI on this branch HEAD: green.
- Image `ghcr.io/mintproject/graphql-engine:gsd-phase-12-is-optional` and SHA tag pushed.

## Test plan

- [x] CI builds green on slashed branch
- [x] Sanitized branch tag (`gsd-phase-12-is-optional`) and SHA tag both visible in registry